### PR TITLE
Custom user file header fields returned by readFileHeader. Fix of readIndex for older scan filter strings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+src/*.o
+src/*.so
+src/*.dll

--- a/R/rawR.R
+++ b/R/rawR.R
@@ -139,10 +139,19 @@ readFileHeader <- function(rawfile,
 
         if (rvs == 0){
 
+            ## Replace backslashes in Instrument method file path to ensure
+            ## the R file can be parsed
+            r_file <- readLines(tf)
+            r_file[12] <- gsub('\\\\','/',r_file[12])
+            writeLines(r_file,tf)
+
             rv <- try({
                 e <- new.env();
                 e$info <- list()
                 source(tf, local=TRUE)
+
+                ## Keep only the file name for the Instrument method
+                e$info$`Instrument method` <- basename(e$info$`Instrument method`)
 
                 #message(paste("unlinking", tf, "..."))
                 #unlink(tf)

--- a/R/rawR.R
+++ b/R/rawR.R
@@ -187,7 +187,7 @@ readFileHeader <- function(rawfile,
 #' plot(Idx$rtinseconds, Idx$precursorMass, col=as.factor(Idx$charge), pch=16)
 readIndex <- function(rawfile, tmpdir=tempdir()){
     mono <- if(Sys.info()['sysname'] %in% c("Darwin", "Linux")) TRUE else FALSE
-    exe <- file.path(path.package(package = "rawR"), "exec", "rawR.exe")
+    exe <- system.file('exec/rawR.exe',package = 'rawR')
 
     rawfile <- normalizePath(rawfile)
 

--- a/R/rawR.R
+++ b/R/rawR.R
@@ -22,7 +22,7 @@
 }
 
 .isMonoAssemblyWorking <-
-    function(exe = file.path(path.package(package = "rawR"), "exec", "rawR.exe")){
+    function(exe = system.file('exec/rawR.exe',package = 'rawR')){
         if(Sys.info()['sysname'] %in% c("Darwin", "Linux")){
             if (Sys.which('mono') == ""){
                 warning("Can not find Mono JIT compiler. check SystemRequirements.")
@@ -105,7 +105,7 @@ is.rawRspectrum <- function(x){
 #' M <- readFileHeader(rawfile)
 readFileHeader <- function(rawfile,
    mono = if(Sys.info()['sysname'] %in% c("Darwin", "Linux")) TRUE else FALSE,
-   exe = file.path(path.package(package = "rawR"), "exec", "rawR.exe"),
+   exe = system.file('exec/rawR.exe',package = 'rawR'),
    mono_path = "",
    argv = "infoR",
    system2_call = TRUE,

--- a/exec/.gitignore
+++ b/exec/.gitignore
@@ -1,0 +1,3 @@
+ThermoFisher.CommonCore.Data.dll
+ThermoFisher.CommonCore.MassPrecisionEstimator.dll
+ThermoFisher.CommonCore.RawFileReader.dll

--- a/exec/.gitignore
+++ b/exec/.gitignore
@@ -1,3 +1,4 @@
 ThermoFisher.CommonCore.Data.dll
 ThermoFisher.CommonCore.MassPrecisionEstimator.dll
 ThermoFisher.CommonCore.RawFileReader.dll
+rawR.exe

--- a/man/readChromatogram.Rd
+++ b/man/readChromatogram.Rd
@@ -58,7 +58,7 @@ iRTpeptide <- c("LGGNEQVTR", "YILAGVENSK", "GTFIIDPGGVIR", "GTFIIDPAAVIR",
   "TPVITGAPYEYR", "DGLDAASYYAPVR", "ADVTPADFSEWSK",
   "LFLQFGAQGSPFLK")
 
-# [2H+] 
+# [2H+]
 if (require(protViz)){
      (mZ <- (parentIonMass(iRTpeptide) + 1.008) / 2)
   }else{

--- a/man/readFileHeader.Rd
+++ b/man/readFileHeader.Rd
@@ -7,7 +7,7 @@
 readFileHeader(
   rawfile,
   mono = if (Sys.info()["sysname"] \%in\% c("Darwin", "Linux")) TRUE else FALSE,
-  exe = file.path(path.package(package = "rawR"), "exec", "rawR.exe"),
+  exe = system.file("exec/rawR.exe", package = "rawR"),
   mono_path = "",
   argv = "infoR",
   system2_call = TRUE,

--- a/man/readIndex.Rd
+++ b/man/readIndex.Rd
@@ -22,7 +22,7 @@ Read scan index
 \examples{
 (rawfile <- file.path(path.package(package = 'rawR'), 'extdata',
   'sample.raw'))
-  
+
 Idx <- readIndex(rawfile)
 table(Idx$scanType)
 plot(Idx$rtinseconds, Idx$precursorMass, col=as.factor(Idx$charge), pch=16)

--- a/man/readSpectrum.Rd
+++ b/man/readSpectrum.Rd
@@ -20,13 +20,13 @@ uses \code{tempdir()}.}
 \item{validate}{boolean default is \code{FALSE}.}
 }
 \value{
-a nested list of \code{rawRspectrum} objects containing more than 50 
+a nested list of \code{rawRspectrum} objects containing more than 50
 values of scan information, e.g., the charge state, two vectors containing
-the mZ and its corresponding intensity values or the AGC information, 
+the mZ and its corresponding intensity values or the AGC information,
 mass calibration, ion optics \ldots
 }
 \description{
-the function derives spectra of a given rawfile and a given 
+the function derives spectra of a given rawfile and a given
 vector of scan numbers.
 }
 \details{
@@ -52,7 +52,7 @@ names(S[[1]])
 
 plot(S[[1]])
 
- 
+
 \dontrun{
 # INPUT:
 GAG <- "GAGSSEPVTGLDAK"
@@ -86,7 +86,7 @@ cat(paste(S[[idx]]$mZ[rv$idx], "\t", S[[idx]]$intensity[rv$idx]), sep = "\n")
   \item{Thermo Fisher NewRawfileReader C# code snippets
     \url{https://planetorbitrap.com/rawfilereader}}.
   \item{\url{https://doi.org/10.5281/zenodo.2640013}}
-  \item{the R function 1st appeared in 
+  \item{the R function 1st appeared in
     \url{https://doi.org/10.1021/acs.jproteome.8b00173}.
   }
 }

--- a/rawR.Rproj
+++ b/rawR.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/rawR.Rproj
+++ b/rawR.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,1 @@
+rawR.xml

--- a/src/rawR.cs
+++ b/src/rawR.cs
@@ -115,7 +115,9 @@
                     Console.WriteLine("e$info$Description <- '" + rawFile.FileHeader.FileDescription + "'");
                     Console.WriteLine("e$info$`Instrument model` <- '{0}'", rawFile.GetInstrumentData().Model);
                     Console.WriteLine("e$info$`Instrument name` <- '{0}'", rawFile.GetInstrumentData().Name);
-                   // Console.WriteLine("e$info$`Instrument method` <- '{0}'", rawFile.GetAllInstrumentFriendlyNamesFromInstrumentMethod().Length);
+                    Console.WriteLine("e$info$`Instrument method` <- '" + rawFile.SampleInformation.InstrumentMethodFile + "'");
+                    //Console.WriteLine("e$info$`Instrument method` <- gsub('\\\\','/','" + rawFile.SampleInformation.InstrumentMethodFile + "',fixed = TRUE)");
+                    //Console.WriteLine("e$info$`Instrument method` <- '{0}'", rawFile.GetAllInstrumentFriendlyNamesFromInstrumentMethod().Length);
                     Console.WriteLine("e$info$`Serial number` <- '{0}'", rawFile.GetInstrumentData().SerialNumber);
                     Console.WriteLine("e$info$`Software version` <- '{0}'", rawFile.GetInstrumentData().SoftwareVersion);
                     Console.WriteLine("e$info$`Firmware version` <- '{0}'", rawFile.GetInstrumentData().HardwareVersion);

--- a/src/rawR.cs
+++ b/src/rawR.cs
@@ -164,7 +164,7 @@
 
                     double charge, precursorMass;
 
-                    Console.WriteLine("scan,scanType,rtinseconds,precursorMass,MSOrder,charge");
+                    Console.WriteLine("scan;scanType;rtinseconds;precursorMass;MSOrder;charge");
 
              	    for  (int scanNumber = firstScanNumber; scanNumber < lastScanNumber; scanNumber++){
                         var scanTrailer = rawFile.GetTrailerExtraInformation(scanNumber);
@@ -185,7 +185,7 @@
 			        charge = -1;
 		        }
 
-                    Console.WriteLine("{0},{1},{2},{3},{4},{5}", scanNumber,
+                    Console.WriteLine("{0};{1};{2};{3};{4};{5}", scanNumber,
 		    	scanStatistics.ScanType.ToString(),
 			Math.Round(scanStatistics.StartTime * 60 * 1000) / 1000,
 			precursorMass,
@@ -250,11 +250,11 @@
 		        }
 
                         file.WriteLine("e$Spectrum[[{0}]] <- list(", scanNumber);
-                        file.WriteLine("\tscan = {0},", scanNumber);
-                        file.WriteLine("\tscanType = \"{0}\",", scanStatistics.ScanType.ToString());
-                        file.WriteLine("\trtinseconds = {0},", Math.Round(scanStatistics.StartTime * 60 * 1000) / 1000);
-                        file.WriteLine("\tprecursorMass = {0},", pc);
-			file.WriteLine("\tMSOrder = '{0}',", scanFilter.MSOrder.ToString());
+                        file.WriteLine("\tscan = {0};", scanNumber);
+                        file.WriteLine("\tscanType = \"{0}\";", scanStatistics.ScanType.ToString());
+                        file.WriteLine("\trtinseconds = {0};", Math.Round(scanStatistics.StartTime * 60 * 1000) / 1000);
+                        file.WriteLine("\tprecursorMass = {0};", pc);
+			file.WriteLine("\tMSOrder = '{0}';", scanFilter.MSOrder.ToString());
                         file.WriteLine("\tcharge = {0}", charge);
                                 file.WriteLine(")");
 		    }

--- a/src/rawR.cs
+++ b/src/rawR.cs
@@ -116,7 +116,6 @@
                     Console.WriteLine("e$info$`Instrument model` <- '{0}'", rawFile.GetInstrumentData().Model);
                     Console.WriteLine("e$info$`Instrument name` <- '{0}'", rawFile.GetInstrumentData().Name);
                     Console.WriteLine("e$info$`Instrument method` <- '" + rawFile.SampleInformation.InstrumentMethodFile + "'");
-                    //Console.WriteLine("e$info$`Instrument method` <- gsub('\\\\','/','" + rawFile.SampleInformation.InstrumentMethodFile + "',fixed = TRUE)");
                     //Console.WriteLine("e$info$`Instrument method` <- '{0}'", rawFile.GetAllInstrumentFriendlyNamesFromInstrumentMethod().Length);
                     Console.WriteLine("e$info$`Serial number` <- '{0}'", rawFile.GetInstrumentData().SerialNumber);
                     Console.WriteLine("e$info$`Software version` <- '{0}'", rawFile.GetInstrumentData().SoftwareVersion);

--- a/src/rawR.cs
+++ b/src/rawR.cs
@@ -1,5 +1,5 @@
     /*
-      aGetTrailerExtraInformationdapded from the ThermoFischer `Hello, world!` example provided by Jim Shofstahl 
+      aGetTrailerExtraInformationdapded from the ThermoFischer `Hello, world!` example provided by Jim Shofstahl
       see URL http://planetorbitrap.com/rawfilereader#.WjkqIUtJmL4
       the ThermoFisher library has to be manual downloaded and installed
       Please read the License document
@@ -15,7 +15,7 @@
       2020-08-12 added infoR option
       2020-08-26 readSpectrum backend
     */
-     
+
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
@@ -148,6 +148,12 @@
                     Console.WriteLine("e$info$`Sample row number` <- '{0}' ", rawFile.SampleInformation.RowNumber);
                     Console.WriteLine("e$info$`Sample dilution factor` <- '{0}' ", rawFile.SampleInformation.DilutionFactor);
                     Console.WriteLine("e$info$`Sample barcode` <- '{0}' ", rawFile.SampleInformation.Barcode);
+
+                    Console.WriteLine("e$info$`User text 0` <- '{0}' ", rawFile.SampleInformation.UserText[0]);
+                    Console.WriteLine("e$info$`User text 1` <- '{0}' ", rawFile.SampleInformation.UserText[1]);
+                    Console.WriteLine("e$info$`User text 2` <- '{0}' ", rawFile.SampleInformation.UserText[2]);
+                    Console.WriteLine("e$info$`User text 3` <- '{0}' ", rawFile.SampleInformation.UserText[3]);
+                    Console.WriteLine("e$info$`User text 4` <- '{0}' ", rawFile.SampleInformation.UserText[4]);
 	    }
 
             public static void GetIndex(this IRawDataPlus rawFile){
@@ -178,7 +184,7 @@
                         } catch {
 			        charge = -1;
 		        }
-		    
+
                     Console.WriteLine("{0},{1},{2},{3},{4},{5}", scanNumber,
 		    	scanStatistics.ScanType.ToString(),
 			Math.Round(scanStatistics.StartTime * 60 * 1000) / 1000,
@@ -227,7 +233,7 @@
                         var scanEvent = rawFile.GetScanEventForScanNumber(scanNumber);
 			var scanFilter = rawFile.GetFilterForScanNumber(scanNumber);
 
-		       
+
 		        try{
                         var reaction0 = scanEvent.GetReaction(0);
 		        pc =  reaction0.PrecursorMass;
@@ -280,7 +286,7 @@
                         var centroidStream = rawFile.GetCentroidStream(scanNumber, false);
                         var scanTrailer = rawFile.GetTrailerExtraInformation(scanNumber);
                         var scanEvent = rawFile.GetScanEventForScanNumber(scanNumber);
-                        
+
                         try
                         {
                             var reaction0 = scanEvent.GetReaction(0);
@@ -404,7 +410,7 @@
 
                 // Get the memory used at the beginning of processing
                 Process processBefore = Process.GetCurrentProcess();
-                
+
                 long memoryBefore = processBefore.PrivateMemorySize64 / 1024;
 
                 try
@@ -455,7 +461,7 @@
 
                     if (string.IsNullOrEmpty(filename))
                     {
-                        
+
                         Console.WriteLine("No RAW file specified!");
 
                         return;
@@ -466,7 +472,7 @@
                     {
                         Console.WriteLine("rawR version = {}", rawR_version);
                         Console.WriteLine(@"The file doesn't exist in the specified location - {0}", filename);
-                        
+
                         return;
                     }
 
@@ -484,7 +490,7 @@
                     if (rawFile.IsError)
                     {
                         Console.WriteLine("Error opening ({0}) - {1}", rawFile.FileError, filename);
-                        
+
                         return;
                     }
 
@@ -541,13 +547,13 @@
                         }
                         Environment.Exit(0);
                     }
-                    
+
                     if (mode == "version")
                     {
-                         Console.WriteLine("version={}", rawR_version);   
+                         Console.WriteLine("version={}", rawR_version);
                          Environment.Exit(0);
                     }
-                    
+
                     if (mode == "chromatogram")
                     {
                         // Get the BasePeak chromatogram for the MS data
@@ -596,7 +602,7 @@
 
                     if (mode == "xic")
                     {
-                        try   
+                        try
                         {
                             var inputFilename = args[2];
                             double ppmError = Convert.ToDouble(args[3]);
@@ -683,7 +689,7 @@
                         MassRanges = new[] {ThermoFisher.CommonCore.Data.Business.Range.Create(50, 2000000)}
 			};
 
-                // Get the chromatogram from the RAW file. 
+                // Get the chromatogram from the RAW file.
                 var dataTIC = rawFile.GetChromatogramData(new IChromatogramSettings[] {settingsTIC}, startScan, endScan);
                 var dataMassRange = rawFile.GetChromatogramData(new IChromatogramSettings[] {settingsMassRange}, startScan, endScan);
                 var dataBasePeak = rawFile.GetChromatogramData(new IChromatogramSettings[] {settingsBasePeak}, startScan, endScan);
@@ -716,8 +722,8 @@
 	    {
 		    if (rawFile.GetFilterFromString(filter) == null) {
 			    return false;
-		    } 
-		    return true; 
+		    }
+		    return true;
 	    }
 
             private static void ExtractIonChromatogramAsRcode(IRawDataPlus rawFile, int startScan, int endScan, List<double> massList,
@@ -750,7 +756,7 @@
                 IChromatogramSettings[] allSettings = settingList.ToArray();
 
                 var data = rawFile.GetChromatogramData(allSettings, startScan, endScan);
-                
+
                 // Split the data into the chromatograms
                 var trace = ChromatogramSignal.FromChromatogramData(data);
 
@@ -763,7 +769,7 @@
                     {
                         List<double> tTime = new List<double>();
                         List<double> tIntensities = new List<double>();
-                        
+
                         for (int j = 0; j < trace[i].Times.Count; j++)
                         {
                             if (trace[i].Intensities[j] > 0)
@@ -771,9 +777,9 @@
                                 tTime.Add(trace[i].Times[j]);
                                 tIntensities.Add(trace[i].Intensities[j]);
                             }
-                            
+
                         }
-                       
+
                         file.WriteLine("e$chromatogram[[{0}]] <- list(", i + 1);
                         file.WriteLine("\tfilter = '{0}',", filter);
                         file.WriteLine("\tppm = {0},", ppmError);


### PR DESCRIPTION
* Additions to enable custom user fields to be returned from raw file header. This includes 5 extra fields that are named `User text 0`, `User text 1`, etc.

* Input file paths for `readFileHeader()` and `readIndex()` normalised prior to system call incase shortcuts such as `~` are present in the file path.

* Fix of `readIndex` to ensure correct parsing of temporary csv for older scan filters that can contain commas such as `FTMS {1,1} - p ESI Full ms [63.00-1000.00]`. `,` separator now substituted with `;`. 